### PR TITLE
feat(587): Add lastCommitMessage to parsed hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -321,6 +321,8 @@ class GitlabScm extends Scm {
             parsed.checkoutUrl = webhookPayload.project.git_http_url;
             parsed.branch = webhookPayload.ref.split('/').slice(-1)[0];
             parsed.sha = webhookPayload.checkout_sha;
+            parsed.lastCommitMessage = Hoek.reach(webhookPayload,
+                    'commits.-1.message', { default: '' });
 
             return Promise.resolve(parsed);
         }

--- a/test/data/gitlab.push.json
+++ b/test/data/gitlab.push.json
@@ -42,6 +42,21 @@
         "my_script.sh"
       ],
       "removed": []
+    },
+    {
+      "id": "76506776e7931f843206c54586266468aec1a92e",
+      "message": "lastcommitmessage",
+      "timestamp": "2017-03-11T08:46:29+00:00",
+      "url": "http://example.com/bdangit/quickstart-generic/commit/76506776e7931f843206c54586266468aec1a92e",
+      "author": {
+        "name": "bdangit",
+        "email": "dev-null@email.com"
+      },
+      "added": [],
+      "modified": [
+        "my_script.sh"
+      ],
+      "removed": []
     }
   ],
   "total_commits_count": 1,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -279,6 +279,7 @@ describe('index', function () {
                 checkoutUrl: 'http://example.com/bdangit/quickstart-generic.git',
                 branch: 'master',
                 sha: '76506776e7931f843206c54586266468aec1a92e',
+                lastCommitMessage: 'lastcommitmessage',
                 hookId: null
             };
             const headers = {


### PR DESCRIPTION
## Context

I'd like to implement the skipping builds feature (screwdriver-cd/screwdriver#587)
I've already changed `scm-github` and `scm-bitbucket` module to do it (screwdriver-cd/scm-github#64 , screwdriver-cd/scm-bitbucket#40)

## Objective

This PR adds lastCommitMessage to the result of `parseHook`.

## References

- issue: screwdriver-cd/screwdriver#587
- webhook spec: https://docs.gitlab.com/ce/user/project/integrations/webhooks.html