### PR TITLE
feat(365)-7: Add getScmContexts and canHandleWebhook functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ const scm = new GitlabScm({
 
 ### Methods
 
+#### getScmContexts
+
+No parameters are required.
+
+##### Expected Outcome
+
+A single element array of ScmContext(ex: `['gitlab:gitlab.com']`(default), `['gitlab:mygitlab.com']`), which will be a unique identifier for the scm.
+
 For more information on the exposed methods please see the [scm-base-class].
 
 ## Testing

--- a/index.js
+++ b/index.js
@@ -739,7 +739,13 @@ class GitlabScm extends Scm {
     * @param  {Response} Object          Object containing stats for the executor
     */
     stats() {
-        return this.breaker.stats();
+        const stats = this.breaker.stats();
+        const scmContexts = this._getScmContexts();
+        const scmContext = scmContexts[0];
+
+        return {
+            [scmContext]: stats
+        };
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -247,6 +247,7 @@ class GitlabScm extends Scm {
      * @method _addWebhook
      * @param  {Object}    config            Config object
      * @param  {String}    config.scmUri     The SCM URI to add the webhook to
+     * @param  {String}    config.scmContext The scm conntext to which user belongs
      * @param  {String}    config.token      Service token to authenticate with Gitlab
      * @param  {String}    config.webhookUrl The URL to use for the webhook notifications
      * @return {Promise}                     Resolve means operation completed without failure.
@@ -272,6 +273,7 @@ class GitlabScm extends Scm {
     * @param  {Object}     config              Config object
     * @param  {String}     config.checkoutUrl  The checkoutUrl to parse
     * @param  {String}     config.token        The token used to authenticate to the SCM service
+    * @param  {String}     config.scmContext   The scm context to which user belongs
     * @return {Promise}                        Resolves to an ID of 'serviceName:repoId:branchName'
     */
     _parseUrl(config) {
@@ -363,6 +365,7 @@ class GitlabScm extends Scm {
     * @param  {String}    config.org           Scm org name
     * @param  {String}    config.repo          Scm repo name
     * @param  {String}    config.sha           Commit sha
+    * @param  {String}    config.scmContext    The scm context to which user belongs
     * @param  {String}    [config.prRef]       PR reference (can be a PR branch or reference)
     * @return {Promise}
     */
@@ -403,9 +406,11 @@ class GitlabScm extends Scm {
     * related information. If a branch suffix is not provided, it will default
     * to the master branch
     * @method _decorateUrl
-    * @param  {Config}    config        Configuration object
-    * @param  {String}    config.scmUri The SCM URI the commit belongs to
-    * @param  {String}    config.token  Service token to authenticate with Github
+    * @param  {Config}    config            Configuration object
+    * @param  {String}    config.scmUri     The SCM URI the commit belongs to
+    * @param  {String}    config.token      Service token to authenticate with Github
+    * @param  {Object}    config.sha        SHA to decorate data with
+    * @param  {String}    config.scmContext The scm context to which user belongs
     * @return {Promise}
     */
     _decorateUrl(config) {
@@ -426,13 +431,15 @@ class GitlabScm extends Scm {
     /**
     * Decorate the commit based on the repository
     * @method _decorateCommit
-    * @param  {Object}        config        Configuration object
-    * @param  {Object}        config.scmUri SCM URI the commit belongs to
-    * @param  {Object}        config.sha    SHA to decorate data with
-    * @param  {Object}        config.token  Service token to authenticate with Github
+    * @param  {Object}        config            Configuration object
+    * @param  {Object}        config.scmUri     SCM URI the commit belongs to
+    * @param  {Object}        config.sha        SHA to decorate data with
+    * @param  {Object}        config.token      Service token to authenticate with Github
+    * @param  {Object}        config.scmContext Context to which user belongs
     * @return {Promise}
     */
     _decorateCommit(config) {
+        const scmContext = config.scmContext;
         const commitLookup = this.lookupScmUri({
             scmUri: config.scmUri,
             token: config.token
@@ -463,7 +470,8 @@ class GitlabScm extends Scm {
 
             return this.decorateAuthor({
                 token: config.token,
-                username: commitData.commitInfo.author_name
+                username: commitData.commitInfo.author_name,
+                scmContext
             });
         });
 
@@ -484,9 +492,10 @@ class GitlabScm extends Scm {
     /**
     * Decorate the author based on the Gitlab service
     * @method _decorateAuthor
-    * @param  {Object}        config          Configuration object
-    * @param  {Object}        config.token    Service token to authenticate with Gitlab
-    * @param  {Object}        config.username Username to query more information for
+    * @param  {Object}        config            Configuration object
+    * @param  {Object}        config.token      Service token to authenticate with Gitlab
+    * @param  {Object}        config.username   Username to query more information for
+    * @param  {String}        config.scmContext The scm context to which user belongs
     * @return {Promise}
     */
     _decorateAuthor(config) {
@@ -528,6 +537,7 @@ class GitlabScm extends Scm {
     * @param  {Object}   config            Configuration
     * @param  {String}   config.scmUri     The scmUri to get permissions on
     * @param  {String}   config.token      The token used to authenticate to the SCM
+    * @param  {String}   config.scmContext The scm context to which user belongs
     * @return {Promise}
     */
     _getPermissions(config) {
@@ -583,6 +593,7 @@ class GitlabScm extends Scm {
     * @method getCommitSha
     * @param  {Object}   config            Configuration
     * @param  {String}   config.scmUri     The scmUri to get commit sha of
+    * @param  {String}   config.scmContext The scm context to which user belongs
     * @param  {String}   config.token      The token used to authenticate to the SCM
     * @return {Promise}
     */
@@ -615,6 +626,7 @@ class GitlabScm extends Scm {
     * @param  {String}   config.token        The token used to authenticate to the SCM
     * @param  {String}   [config.jobName]    Optional name of the job that finished
     * @param  {String}   config.url          Target url
+    * @param  {String}   config.scmContext   The scm context to which user belongs
     * @return {Promise}
     */
     _updateCommitStatus(config) {
@@ -648,6 +660,7 @@ class GitlabScm extends Scm {
     * @param  {String}   config.path         The file in the repo to fetch
     * @param  {String}   config.token        The token used to authenticate to the SCM
     * @param  {String}   config.ref          The reference to the SCM, either branch or sha
+    * @param  {String}   config.scmContext   The scm context to which user belongs
     * @return {Promise}
     */
     _getFile(config) {

--- a/index.js
+++ b/index.js
@@ -240,7 +240,7 @@ class GitlabScm extends Scm {
         });
     }
 
-    /** Extended from screwdriver-scm-base **/
+    /** Extended from screwdriver-scm-base */
 
     /**
      * Adds the Screwdriver webhook to the Gitlab repository
@@ -693,9 +693,7 @@ class GitlabScm extends Scm {
     _getBellConfiguration() {
         const scmContexts = this._getScmContexts();
         const scmContext = scmContexts[0];
-        const cookie = this.config.gitlabHost
-            ? `gitlab-${this.config.gitlabHost}`
-            : 'gitlab-gitlab.com';
+        const cookie = `gitlab-${this.config.gitlabHost}`;
         const bellConfig = {};
 
         bellConfig[scmContext] = {
@@ -771,11 +769,7 @@ class GitlabScm extends Scm {
      * @return {Array}
      */
     _getScmContexts() {
-        const contextName = this.config.gitlabHost
-            ? [`gitlab:${this.config.gitlabHost}`]
-            : ['gitlab:gitlab.com'];
-
-        return contextName;
+        return [`gitlab:${this.config.gitlabHost}`];
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -278,6 +278,13 @@ class GitlabScm extends Scm {
     */
     _parseUrl(config) {
         const repoInfo = getRepoInfoByCheckoutUrl(config.checkoutUrl);
+        const myHost = this.config.gitlabHost || 'gitlab.com';
+
+        if (repoInfo.hostname !== myHost) {
+            const message = 'This checkoutUrl is not supported for your current login host.';
+
+            return Promise.reject(new Error(message));
+        }
 
         return this.breaker.runCommand({
             json: true,
@@ -769,7 +776,9 @@ class GitlabScm extends Scm {
      * @return {Array}
      */
     _getScmContexts() {
-        return [`gitlab:${this.config.gitlabHost}`];
+        return this.config.gitlabHost
+            ? [`gitlab:${this.config.gitlabHost}`]
+            : ['gitlab:gitlab.com'];
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -693,10 +693,14 @@ class GitlabScm extends Scm {
     _getBellConfiguration() {
         const scmContexts = this._getScmContexts();
         const scmContext = scmContexts[0];
+        const cookie = this.config.gitlabHost
+            ? `gitlab-${this.config.gitlabHost}`
+            : 'gitlab-gitlab.com';
         const bellConfig = {};
 
         bellConfig[scmContext] = {
             provider: 'gitlab',
+            cookie,
             clientId: this.config.oauthClientId,
             clientSecret: this.config.oauthClientSecret,
             isSecure: this.config.https,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-scm-gitlab",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "GitLab implementation for the scm-base class",
   "main": "index.js",
   "scripts": {
@@ -35,8 +35,8 @@
     "hoek": "^4.1.0",
     "joi": "^10.2.2",
     "request": "^2.80.0",
-    "screwdriver-data-schema": "^16.3.0",
-    "screwdriver-scm-base": "^2.6.0"
+    "screwdriver-data-schema": "^17.0.0",
+    "screwdriver-scm-base": "^3.0.0"
   },
   "release": {
     "debug": false,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1193,7 +1193,8 @@ describe('index', function () {
                         },
                         forceHttps: false,
                         isSecure: false,
-                        provider: 'gitlab'
+                        provider: 'gitlab',
+                        cookie: 'gitlab-gitlab.com'
                     }
                 });
             })
@@ -1215,7 +1216,8 @@ describe('index', function () {
                     },
                     forceHttps: false,
                     isSecure: false,
-                    provider: 'gitlab'
+                    provider: 'gitlab',
+                    cookie: 'gitlab-mygitlab.com'
                 }
             };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -218,7 +218,8 @@ describe('index', function () {
                 sha: '249b26f2278c39f9efc55986f845dd98ae011763',
                 prNum: 6,
                 prRef: 'merge_requests/6',
-                hookId: null
+                hookId: null,
+                scmContext: 'gitlab:gitlab.com'
             };
             const headers = {
                 'content-type': 'application/json',
@@ -239,7 +240,8 @@ describe('index', function () {
                 sha: 'bc2b3a48a428ed23e15960e8d703bf7e3a8a4f54',
                 prNum: 2,
                 prRef: 'merge_requests/2',
-                hookId: null
+                hookId: null,
+                scmContext: 'gitlab:gitlab.com'
             };
             const headers = {
                 'content-type': 'application/json',
@@ -260,7 +262,8 @@ describe('index', function () {
                 sha: 'bc2b3a48a428ed23e15960e8d703bf7e3a8a4f54',
                 prNum: 2,
                 prRef: 'merge_requests/2',
-                hookId: null
+                hookId: null,
+                scmContext: 'gitlab:gitlab.com'
             };
             const headers = {
                 'content-type': 'application/json',
@@ -279,7 +282,8 @@ describe('index', function () {
                 checkoutUrl: 'http://example.com/bdangit/quickstart-generic.git',
                 branch: 'master',
                 sha: '76506776e7931f843206c54586266468aec1a92e',
-                hookId: null
+                hookId: null,
+                scmContext: 'gitlab:gitlab.com'
             };
             const headers = {
                 'content-type': 'application/json',
@@ -1139,17 +1143,44 @@ describe('index', function () {
         it('resolves a default configuration', () =>
             scm.getBellConfiguration().then((config) => {
                 assert.deepEqual(config, {
-                    clientId: 'myclientid',
-                    clientSecret: 'myclientsecret',
+                    'gitlab:gitlab.com': {
+                        clientId: 'myclientid',
+                        clientSecret: 'myclientsecret',
+                        config: {
+                            uri: 'https://gitlab.com'
+                        },
+                        forceHttps: false,
+                        isSecure: false,
+                        provider: 'gitlab'
+                    }
+                });
+            })
+        );
+
+        it('resolves a configuration for gitlabHost chenged from default', () => {
+            scm = new GitlabScm({
+                oauthClientId: 'abcdef',
+                oauthClientSecret: 'hijklm',
+                gitlabHost: 'mygitlab.com'
+            });
+
+            const expected = {
+                'gitlab:mygitlab.com': {
+                    clientId: 'abcdef',
+                    clientSecret: 'hijklm',
                     config: {
-                        uri: 'https://gitlab.com'
+                        uri: 'https://mygitlab.com'
                     },
                     forceHttps: false,
                     isSecure: false,
                     provider: 'gitlab'
-                });
-            })
-        );
+                }
+            };
+
+            return scm.getBellConfiguration().then((config) => {
+                assert.deepEqual(config, expected);
+            });
+        });
     });
 
     describe('getCheckoutCommand', () => {
@@ -1486,6 +1517,106 @@ describe('index', function () {
                     }
                 ]);
             });
+        });
+    });
+
+    describe('getScmContexts', () => {
+        it('returns a default scmContext', () => {
+            const result = scm.getScmContexts();
+
+            return assert.deepEqual(result, ['gitlab:gitlab.com']);
+        });
+
+        it('returns a scmContext for user setting gitlabHost', () => {
+            scm = new GitlabScm({
+                oauthClientId: 'abcdef',
+                oauthClientSecret: 'hijklm',
+                gitlabHost: 'mygitlab.com'
+            });
+
+            const result = scm.getScmContexts();
+
+            return assert.deepEqual(result, ['gitlab:mygitlab.com']);
+        });
+    });
+
+    describe('canHandleWebhook', () => {
+        it('returns a true for opened PR', () => {
+            const headers = {
+                'content-type': 'application/json',
+                'x-gitlab-event': 'Merge Request Hook'
+            };
+
+            return scm.canHandleWebhook(headers, testPayloadOpen)
+                .then((result) => {
+                    assert.strictEqual(result, true);
+                });
+        });
+
+        it('returns a true for closed PR', () => {
+            const headers = {
+                'content-type': 'application/json',
+                'x-gitlab-event': 'Merge Request Hook'
+            };
+
+            return scm.canHandleWebhook(headers, testPayloadClose)
+                .then((result) => {
+                    assert.strictEqual(result, true);
+                });
+        });
+
+        it('returns a true for push to repo event', () => {
+            const headers = {
+                'content-type': 'application/json',
+                'x-gitlab-event': 'Push Hook'
+            };
+
+            return scm.canHandleWebhook(headers, testPayloadPush)
+                .then((result) => {
+                    assert.strictEqual(result, true);
+                });
+        });
+
+        it('returns a false for scm not supporting', () => {
+            const headers = {
+                'x-hub-signature': 'sha1=a72eab99ad7f36f582f224df8d735091b06f1802',
+                'x-github-event': 'pull_request',
+                'x-github-delivery': '3c77bf80-9a2f-11e6-80d6-72f7fe03ea29'
+            };
+
+            return scm.canHandleWebhook(headers, testPayloadOpen)
+                .then((result) => {
+                    assert.strictEqual(result, false);
+                });
+        });
+
+        it('returns a false when parseHook resolves null', () => {
+            const headers = {
+                'content-type': 'application/json',
+                'x-gitlab-event': 'Push Hook'
+            };
+
+            scm._parseHook = sinon.stub();
+            scm._parseHook.resolves(null);
+
+            return scm.canHandleWebhook(headers, testPayloadOpen)
+                .then((result) => {
+                    assert.strictEqual(result, false);
+                });
+        });
+
+        it('returns a false when parseHook catches some error', () => {
+            const headers = {
+                'content-type': 'application/json',
+                'x-gitlab-event': 'Push Hook'
+            };
+
+            scm._parseHook = sinon.stub().rejects();
+
+            return scm.canHandleWebhook(headers, testPayloadOpen)
+                .then((result) => {
+                    assert.strictEqual(result, false);
+                });
         });
     });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -90,6 +90,7 @@ describe('index', function () {
 
     describe('parseUrl', () => {
         const apiUrl = 'https://gitlab.com/api/v3/projects/batman%2Ftest';
+        const scmContext = 'gitlab:gitlab.com';
         let fakeResponse;
         let expectedOptions;
 
@@ -126,7 +127,8 @@ describe('index', function () {
 
             return scm.parseUrl({
                 checkoutUrl: 'git@gitlab.com:batman/test.git#master',
-                token
+                token,
+                scmContext
             }).then((parsed) => {
                 assert.calledWith(requestMock, expectedOptions);
                 assert.equal(parsed, expected);
@@ -139,7 +141,8 @@ describe('index', function () {
 
             return scm.parseUrl({
                 checkoutUrl: 'https://batman@gitlab.com/batman/test.git#mynewbranch',
-                token
+                token,
+                scmContext
             }).then((parsed) => {
                 assert.calledWith(requestMock, expectedOptions);
                 assert.equal(parsed, expected);
@@ -153,7 +156,8 @@ describe('index', function () {
 
             return scm.parseUrl({
                 checkoutUrl: 'https://batman@gitlab.com/batman/test.git#mynewbranch',
-                token
+                token,
+                scmContext
             })
                 .then(() => assert.fail('Should not get here'))
                 .catch((error) => {
@@ -174,7 +178,8 @@ describe('index', function () {
 
             return scm.parseUrl({
                 checkoutUrl: 'https://batman@gitlab.com/batman/test.git#mynewbranch',
-                token
+                token,
+                scmContext
             })
                 .then(() => assert.fail('Should not get here'))
                 .catch((error) => {
@@ -196,7 +201,8 @@ describe('index', function () {
 
             return scm.parseUrl({
                 checkoutUrl: 'https://batman@gitlab.com/batman/test.git#mynewbranch',
-                token
+                token,
+                scmContext
             })
                 .then(() => assert.fail('Should not get here'))
                 .catch((error) => {
@@ -362,6 +368,7 @@ describe('index', function () {
 
             return scm.decorateAuthor({
                 username: 'batman',
+                scmContext: 'gitlab:gitlab.com',
                 token
             }).then((decorated) => {
                 assert.calledWith(requestMock, expectedOptions);
@@ -381,6 +388,7 @@ describe('index', function () {
 
             return scm.decorateAuthor({
                 username: 'batman',
+                scmContext: 'gitlab:gitlab.com',
                 token
             }).then(() => {
                 assert.fail('Should not get here');
@@ -398,6 +406,7 @@ describe('index', function () {
 
             return scm.decorateAuthor({
                 username: 'batman',
+                scmContext: 'gitlab:gitlab.com',
                 token
             }).then(() => {
                 assert.fail('Should not get here');
@@ -410,6 +419,7 @@ describe('index', function () {
 
     describe('decorateUrl', () => {
         const apiUrl = 'https://gitlab.com/api/v3/projects/repoId';
+        const scmContext = 'gitlab:gitlab.com';
         const repoOptions = {
             url: apiUrl,
             method: 'GET',
@@ -449,7 +459,8 @@ describe('index', function () {
 
             return scm.decorateUrl({
                 scmUri: 'hostName:repoId:branchName',
-                token
+                token,
+                scmContext
             }).then((decorated) => {
                 assert.calledWith(requestMock, expectedOptions);
                 assert.deepEqual(decorated, expected);
@@ -468,7 +479,8 @@ describe('index', function () {
 
             return scm.decorateUrl({
                 scmUri: 'hostName:repoId:branchName',
-                token
+                token,
+                scmContext
             }).then(() => {
                 assert.fail('Should not get here');
             }).catch((error) => {
@@ -485,7 +497,8 @@ describe('index', function () {
 
             return scm.decorateUrl({
                 scmUri: 'repoName:repoId:branchName',
-                token
+                token,
+                scmContext
             }).then(() => {
                 assert.fail('Should not get here');
             }).catch((error) => {
@@ -497,6 +510,7 @@ describe('index', function () {
 
     describe('decorateCommit', () => {
         const sha = '1111111111111111111111111111111111111111';
+        const scmContext = 'gitlab:gitlab.com';
         let lookupScmUri;
         let lookupScmUriResponse;
         let commitLookup;
@@ -584,7 +598,8 @@ describe('index', function () {
             return scm.decorateCommit({
                 sha,
                 scmUri: 'hostName:repoId:branchName',
-                token
+                token,
+                scmContext
             }).then((decorated) => {
                 assert.calledThrice(requestMock);
                 assert.deepEqual(decorated, expected);
@@ -605,7 +620,8 @@ describe('index', function () {
             return scm.decorateCommit({
                 sha,
                 scmUri: 'hostName:repoId:branchName',
-                token
+                token,
+                scmContext
             }).then(() => {
                 assert.fail('Should not get here');
             }).catch((error) => {
@@ -623,7 +639,8 @@ describe('index', function () {
             return scm.decorateCommit({
                 sha,
                 scmUri: 'hostName:repoId:branchName',
-                token
+                token,
+                scmContext
             }).then(() => {
                 assert.fail('Should not get here');
             }).catch((error) => {
@@ -637,6 +654,7 @@ describe('index', function () {
         const apiUrl = 'https://gitlab.com/api/v3/projects/repoId' +
                        '/repository/branches/branchName';
         const scmUri = 'hostName:repoId:branchName';
+        const scmContext = 'gitlab:gitlab.com';
         const expectedOptions = {
             url: apiUrl,
             method: 'GET',
@@ -662,7 +680,8 @@ describe('index', function () {
         it('resolves to correct commit sha', () =>
             scm.getCommitSha({
                 scmUri,
-                token
+                token,
+                scmContext
             }).then((sha) => {
                 assert.calledWith(requestMock, expectedOptions);
                 assert.deepEqual(sha, 'hashValue');
@@ -681,7 +700,8 @@ describe('index', function () {
 
             return scm.getCommitSha({
                 scmUri,
-                token
+                token,
+                scmContext
             }).then(() => {
                 assert.fail('Should not get here');
             }).catch((error) => {
@@ -698,7 +718,8 @@ describe('index', function () {
 
             return scm.getCommitSha({
                 scmUri,
-                token
+                token,
+                scmContext
             }).then(() => {
                 assert.fail('Should not get here');
             }).catch((error) => {
@@ -712,8 +733,10 @@ describe('index', function () {
         const apiUrl = 'https://gitlab.com/api/v3/projects/repoId' +
                        '/repository/files';
         const scmUri = 'hostName:repoId:branchName';
+        const scmContext = 'gitlab:gitlab.com';
         const params = {
             scmUri,
+            scmContext,
             token,
             path: 'path/to/file.txt'
         };
@@ -813,10 +836,12 @@ describe('index', function () {
 
         it('get correct permissions for level 50', () => {
             const scmUri = 'hostName:repoId:branchName';
+            const scmContext = 'gitlab:gitlab.com';
 
             return scm.getPermissions({
                 scmUri,
-                token
+                token,
+                scmContext
             }).then((permissions) => {
                 assert.calledOnce(requestMock);
                 assert.calledWith(requestMock, expectedOptions);
@@ -844,10 +869,12 @@ describe('index', function () {
                 .yieldsAsync(null, fakeResponse, fakeResponse.body);
 
             const scmUri = 'hostName:repoId:branchName';
+            const scmContext = 'gitlab:gitlab.com';
 
             return scm.getPermissions({
                 scmUri,
-                token
+                token,
+                scmContext
             }).then((permissions) => {
                 assert.calledOnce(requestMock);
                 assert.calledWith(requestMock, expectedOptions);
@@ -875,10 +902,12 @@ describe('index', function () {
                 .yieldsAsync(null, fakeResponse, fakeResponse.body);
 
             const scmUri = 'hostName:repoId:branchName';
+            const scmContext = 'gitlab:gitlab.com';
 
             return scm.getPermissions({
                 scmUri,
-                token
+                token,
+                scmContext
             }).then((permissions) => {
                 assert.calledOnce(requestMock);
                 assert.calledWith(requestMock, expectedOptions);
@@ -906,10 +935,12 @@ describe('index', function () {
                 .yieldsAsync(null, fakeResponse, fakeResponse.body);
 
             const scmUri = 'hostName:repoId:branchName';
+            const scmContext = 'gitlab:gitlab.com';
 
             return scm.getPermissions({
                 scmUri,
-                token
+                token,
+                scmContext
             }).then((permissions) => {
                 assert.calledOnce(requestMock);
                 assert.calledWith(requestMock, expectedOptions);
@@ -937,10 +968,12 @@ describe('index', function () {
                 .yieldsAsync(null, fakeResponse, fakeResponse.body);
 
             const scmUri = 'hostName:repoId:branchName';
+            const scmContext = 'gitlab:gitlab.com';
 
             return scm.getPermissions({
                 scmUri,
-                token
+                token,
+                scmContext
             }).then((permissions) => {
                 assert.calledOnce(requestMock);
                 assert.calledWith(requestMock, expectedOptions);
@@ -968,10 +1001,12 @@ describe('index', function () {
                 .yieldsAsync(null, fakeResponse, fakeResponse.body);
 
             const scmUri = 'hostName:repoId:branchName';
+            const scmContext = 'gitlab:gitlab.com';
 
             return scm.getPermissions({
                 scmUri,
-                token
+                token,
+                scmContext
             }).then((permissions) => {
                 assert.calledOnce(requestMock);
                 assert.calledWith(requestMock, expectedOptions);
@@ -993,10 +1028,12 @@ describe('index', function () {
                 .yieldsAsync(null, fakeResponse, fakeResponse.body);
 
             const scmUri = 'hostName:repoId:branchName';
+            const scmContext = 'gitlab:gitlab.com';
 
             return scm.getPermissions({
                 scmUri,
-                token
+                token,
+                scmContext
             }).then((permissions) => {
                 assert.calledOnce(requestMock);
                 assert.calledWith(requestMock, expectedOptions);
@@ -1010,6 +1047,7 @@ describe('index', function () {
 
         it('rejects if status code is not 200', () => {
             const scmUri = 'hostName:repoId:branchName';
+            const scmContext = 'gitlab:gitlab.com';
 
             fakeResponse = {
                 statusCode: 404,
@@ -1023,7 +1061,8 @@ describe('index', function () {
 
             return scm.getPermissions({
                 scmUri,
-                token
+                token,
+                scmContext
             }).then(() => {
                 assert.fail('Should not get here');
             }).catch((error) => {
@@ -1035,13 +1074,15 @@ describe('index', function () {
         it('rejects if fails', () => {
             const error = new Error('Gitlab API error');
             const scmUri = 'hostName:repoId:branchName';
+            const scmContext = 'gitlab:gitlab.com';
 
             requestMock.withArgs(expectedOptions)
                 .yieldsAsync(error);
 
             return scm.getPermissions({
                 scmUri,
-                token
+                token,
+                scmContext
             }).then(() => {
                 assert.fail('Should not get here');
             }).catch((err) => {
@@ -1059,6 +1100,7 @@ describe('index', function () {
         beforeEach(() => {
             config = {
                 scmUri: 'hostName:repoId:branchName',
+                scmContext: 'gitlab:gitlab.com',
                 sha: '1111111111111111111111111111111111111111',
                 buildStatus: 'SUCCESS',
                 token,
@@ -1189,7 +1231,8 @@ describe('index', function () {
             host: 'hostName',
             org: 'orgName',
             repo: 'repoName',
-            sha: 'shaValue'
+            sha: 'shaValue',
+            scmContext: 'gitlab:gitlab.com'
         };
 
         it('resolves checkout command without prRef', () =>

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -211,6 +211,20 @@ describe('index', function () {
                                                 'Caller "_parseUrl"');
                 });
         });
+
+        it('rejects when passed checkoutUrl of another host', () => {
+            const expectedError = 'This checkoutUrl is not supported for your current login host.';
+
+            return scm.parseUrl({
+                checkoutUrl: 'git@gitlab.corp.jp:batman/test.git#master',
+                scmContext,
+                token
+            }).then(() => {
+                assert.fail('Should not get here');
+            }, (error) => {
+                assert.match(error.message, expectedError);
+            });
+        });
     });
 
     describe('parseHook', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1224,16 +1224,18 @@ describe('index', function () {
     describe('stats', () => {
         it('returns the correct stats', () => {
             assert.deepEqual(scm.stats(), {
-                requests: {
-                    total: 0,
-                    timeouts: 0,
-                    success: 0,
-                    failure: 0,
-                    concurrent: 0,
-                    averageTime: 0
-                },
-                breaker: {
-                    isClosed: true
+                'gitlab:gitlab.com': {
+                    requests: {
+                        total: 0,
+                        timeouts: 0,
+                        success: 0,
+                        failure: 0,
+                        concurrent: 0,
+                        averageTime: 0
+                    },
+                    breaker: {
+                        isClosed: true
+                    }
                 }
             });
         });


### PR DESCRIPTION
## Context
I'd like to implement the ability to use multiple scms feature (https://github.com/screwdriver-cd/screwdriver/issues/365).
The other related modules are also being modified.

## Objective
This PR adds `_getScmContexts` and `_canHandleWebhook` functions for the multiple scms feature.

## References
issue: https://github.com/screwdriver-cd/screwdriver/issues/365
Before merging for test success: https://github.com/screwdriver-cd/scm-base/pull/43
related changes:
- https://github.com/screwdriver-cd/data-schema/pull/152
- https://github.com/screwdriver-cd/data-schema/pull/155
- https://github.com/screwdriver-cd/screwdriver/pull/632
- https://github.com/screwdriver-cd/models/pull/180
- https://github.com/screwdriver-cd/scm-router/pull/1
- https://github.com/screwdriver-cd/scm-base/pull/43
- https://github.com/screwdriver-cd/scm-github/pull/65
- https://github.com/screwdriver-cd/scm-bitbucket/pull/41